### PR TITLE
use only ascii characters in mongodb_* documents

### DIFF
--- a/src/lovely/testlayers/mongodb_masterslave.txt
+++ b/src/lovely/testlayers/mongodb_masterslave.txt
@@ -1,5 +1,5 @@
 =======================================
-MongoDB test layer » master/slave setup
+MongoDB test layer - master/slave setup
 =======================================
 
 .. note::

--- a/src/lovely/testlayers/mongodb_replicaset.txt
+++ b/src/lovely/testlayers/mongodb_replicaset.txt
@@ -1,5 +1,5 @@
 ======================================
-MongoDB test layer » replica set setup
+MongoDB test layer - replica set setup
 ======================================
 
 .. note::

--- a/src/lovely/testlayers/mongodb_single.txt
+++ b/src/lovely/testlayers/mongodb_single.txt
@@ -1,5 +1,5 @@
 ========================================
-MongoDB test layer » single server setup
+MongoDB test layer - single server setup
 ========================================
 
 .. note::


### PR DESCRIPTION
if setup.py is called with LANG=ascii it will as the txt
    files are read for the long description.