### PR TITLE
OpenLDAP and ApacheDS test layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ develop-eggs/
 /dist/
 /downloads/
 .tox/
+/.idea

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Change History
 Unreleased
 ==========
 - Refactor generic functionality from MongoLayer into WorkspaceLayer
+- Add server layers for OpenLDAP and ApacheDS LDAP servers
 
 
 2015/06/02 0.6.3

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Change History
 
 Unreleased
 ==========
+- Refactor generic functionality from MongoLayer into WorkspaceLayer
+
 
 2015/06/02 0.6.3
 ================

--- a/DEVELOP.txt
+++ b/DEVELOP.txt
@@ -2,12 +2,20 @@
 Development setup for lovely.testlayers
 =======================================
 
+Basics
+======
+
+Development sandbox
+-------------------
 This project uses buildout, so in order to start developing run the
 following in this directory::
 
  python bootstrap.py
  ./bin/buildout
 
+
+Run tests
+---------
 To run tests use::
 
  ./bin/test
@@ -18,6 +26,8 @@ default. To run all tests use::
  ./bin/test --all
 
 
+Run tests with tox
+------------------
 To test against multiple python versions tox can be used. The python
 interpreter need to be available in the `$PATH` variable as `python2.7`,
 `python3.3` and `pypy`. Execute tox using::
@@ -29,14 +39,69 @@ To limit the tox test to a single python interpreter use it like this::
  ./bin/tox -e py27
 
 
+Modules
+=======
+
+
 MongoDB
 -------
-
-The mongodb tests are separated and by default not included if buildout is run.
-To install mongodb execute::
+The MongoDB tests are separated and by default not included if buildout is run.
+To install MongoDB and its test suite, execute::
 
     bin/buildout install mongodb mongodb-test
 
 And then run the tests with::
 
     bin/test-mongodb --suite-name=mongodb_suite
+
+
+OpenLDAP
+--------
+The OpenLDAP tests are separated and by default not included if buildout is run.
+To install the OpenLDAP test suite, execute::
+
+    bin/buildout install openldap-test
+
+And then run the tests with::
+
+    bin/test-openldap
+
+
+The relevant OpenLDAP system packages are not installed by buildout and have to be installed separately.
+
+Debian Linux::
+
+    aptitude install slapd openldap-utils libldap2-dev libsasl2-dev
+
+CentOS Linux::
+
+    yum install openldap-servers openldap-clients
+
+Mac OS X, Macports::
+
+    sudo port install openldap
+
+
+ApacheDS
+--------
+The ApacheDS tests are separated and by default not included if buildout is run.
+To install the ApacheDS test suite, execute::
+
+    bin/buildout install apacheds-test
+
+And then run the tests with::
+
+    bin/test-apacheds
+
+
+The relevant ApacheDS system packages are not installed by buildout and have to be installed separately.
+
+    - https://directory.apache.org/apacheds/downloads.html
+
+Also, a Java runtime is required::
+
+    aptitude install default-jre-headless
+
+Please note even when running ApacheDS, the provisioning of LDIF files depends on "ldapadd",
+to be installed through ``openldap-utils`` or ``openldap-clients`` packages.
+

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -67,3 +67,23 @@ script = test-mongodb
 eggs = lovely.testlayers [mongodb]
 defaults = ['--suite-name=mongodb_suite', '--auto-color']
 requires = ${mongodb:recipe}
+
+
+[openldap-test]
+# Separate test suite and test runner for OpenLDAP tests
+# setup: bin/buildout install openldap-test
+# run:   bin/test-openldap
+recipe = zc.recipe.testrunner
+script = test-openldap
+eggs = lovely.testlayers [ldap]
+defaults = ['--suite-name=openldap_suite', '--auto-color']
+
+
+[apacheds-test]
+# Separate test suite and test runner for ApacheDS tests
+# setup: bin/buildout install apacheds-test
+# run:   bin/test-apacheds
+recipe = zc.recipe.testrunner
+script = test-apacheds
+eggs = lovely.testlayers [ldap]
+defaults = ['--suite-name=apacheds_suite', '--auto-color']

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -50,11 +50,6 @@ command = ${memcached:location}/bin/memcached -U 0 -vv -p ${ports:memcached}
 content = #!/bin/sh
  ${:command} $@
 
-
-# separate test suite and test runner for mongodb
-# setup: bin/buildout install mongodb mongodb-test
-# run:   bin/test-mongodb
-
 [mongodb]
 recipe = rod.recipe.mongodb
 darwin-32bit-url = http://downloads.mongodb.org/osx/mongodb-osx-i386-2.4.4.tgz
@@ -62,7 +57,11 @@ darwin-64bit-url = http://downloads.mongodb.org/osx/mongodb-osx-x86_64-2.4.4.tgz
 linux2-32bit-url = http://downloads.mongodb.org/linux/mongodb-linux-i686-2.4.4.tgz
 linux2-64bit-url = http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.4.4.tgz
 
+
 [mongodb-test]
+# Separate test suite and test runner for MongoDB
+# setup: bin/buildout install mongodb mongodb-test
+# run:   bin/test-mongodb
 recipe = zc.recipe.testrunner
 script = test-mongodb
 eggs = lovely.testlayers [mongodb]

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,14 @@ long_description='\n'.join((
         read('src', 'lovely', 'testlayers', 'mongodb_single.txt'),
         read('src', 'lovely', 'testlayers', 'mongodb_masterslave.txt'),
         read('src', 'lovely', 'testlayers', 'mongodb_replicaset.txt'),
+        read('src', 'lovely', 'testlayers', 'apacheds.txt'),
+        read('src', 'lovely', 'testlayers', 'openldap.txt'),
         read('CHANGES.txt'),
         ))
 
 setup(
     name = 'lovely.testlayers',
-    version = '0.6.3',
+    version = '0.7.0.dev2',
     description="mysql, postgres nginx, memcached cassandra test"+\
                 " layers for use with zope.testrunner",
     long_description=long_description,
@@ -48,7 +50,7 @@ setup(
     author = "Lovely Systems",
     author_email = 'office@lovelysystems.com',
     package_dir = {'':'src'},
-    keywords = "testing zope layer test cassandra memcached",
+    keywords = "testing zope layer test apacheds cassandra memcached mongodb mysql nginx openldap postgresql",
     license = "Apache License 2.0",
     zip_safe = False,
     url = 'https://github.com/lovelysystems/lovely.testlayers',
@@ -59,6 +61,8 @@ setup(
         cassandra=['zc.buildout>=1.4'],
         pgsql=['psycopg2',
                'transaction'],
-        mongodb=['pymongo==2.5.2']),
+        mongodb=['pymongo==2.5.2'],
+        ldap=['python-ldap==2.4.27'],
+    ),
     install_requires = ['setuptools']
     )

--- a/src/lovely/testlayers/apacheds.py
+++ b/src/lovely/testlayers/apacheds.py
@@ -1,0 +1,226 @@
+##############################################################################
+#
+# Copyright 2016 Andreas Motl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
+
+"""
+``lovely.testlayers.apacheds``
+
+Test layer for ApacheDS:
+
+- The ``ApacheDSLayer`` starts and stops a single ApacheDS instance.
+"""
+import os
+import sys
+import logging
+from lovely.testlayers.util import asbool
+from lovely.testlayers.layer import WorkspaceLayer
+from lovely.testlayers.server import ServerLayer
+from lovely.testlayers.openldap import OpenLDAPLayerClientMixin
+
+# Setup logging
+console = logging.StreamHandler()
+console.setFormatter(
+    logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s'))
+logger = logging.getLogger(__name__)
+logger.addHandler(console)
+logger.setLevel(logging.INFO)
+
+
+class ApacheDSLayer(WorkspaceLayer, ServerLayer, OpenLDAPLayerClientMixin):
+    """
+    Encapsulates controlling a single ApacheDS instance.
+    """
+
+    __bases__ = ()
+
+    daemon_candidates = [
+
+        # Debian Linux (DEB)
+        '/opt/apacheds-*/bin/wrapper',
+
+        # Fedora Linux (RPM)
+        '/opt/apacheds-*/bin/wrapper',
+
+        # Mac OS X, Macports
+        '/usr/local/apacheds-*/bin/wrapper',
+
+        ]
+
+    configuration_candidates = [
+
+        # Debian Linux (DEB)
+        '/opt/apacheds-*/conf/wrapper.conf',
+
+        # Fedora Linux (RPM)
+        '/opt/apacheds-*/conf/wrapper.conf',
+
+        # Mac OS X, Macports
+        '/usr/local/apacheds-*/conf/wrapper.conf',
+
+        ]
+
+    def __init__(self, name, apacheds_bin=None, apacheds_conf=None,
+                 host=None, port=None, tls=False,
+                 conf_settings=None,
+                 cleanup=True, extra_options=None):
+        """
+        Settings for ``ApacheDSLayer``
+
+        :name: (required)
+            The first and only positional argument is the layer name.
+
+        :apacheds_bin:
+            The path to ApacheDS' ``wrapper`` executable, defaults to
+            finding the executable from ``self.daemon_candidates``.
+
+        :apacheds_conf:
+            The path to ApacheDS' ``wrapper.conf`` configuration file, defaults to
+            finding the file by honoring $PATH and ``self.configuration_candidates``.
+
+        :host:
+            The hostname to be used for computing the LDAP URI, which in turn gets used
+            by ``ldapadd`` for provisioning the ApacheDS DIT from appropriate LDIF files.
+            Defaults to ``localhost``.
+
+        :port:
+            On which port ApacheDS should listen, defaults to ``10389``.
+
+            ATTENTION: CURRENTLY NOT WORKING WITH ApacheDS. IT IS FIXED ON 10389.
+
+        :tls:
+            Controls LDAP URI schema: ldap:// vs. ldaps://
+            Defaults to ``False``.
+
+        :conf_settings:
+            Dictionary containing configuration settings to be propagated into ``cn=config``.
+
+            ATTENTION: CURRENTLY NOT WORKING WITH ApacheDS. SUFFIX AND ROOTDN/ROOTPW ARE FIXED.
+
+        :cleanup:
+            Whether to erase the workspace directory on setup and teardown.
+            Defaults to ``True``.
+
+        :extra_options:
+            Additional command line options to be passed to the daemon executable,
+            defaults to empty dictionary. Currently unused.
+
+            ATTENTION: CURRENTLY NOT WORKING WITH ApacheDS. There are no extra_options.
+
+        """
+
+        # Essential attributes
+        self.__name__ = name
+        self.__classname__ = self.__class__.__name__
+
+        # Setup workspace
+        self.directories = ('cache', 'conf', 'log', 'partitions', 'run', 'syncrepl-data')
+        self.cleanup = asbool(cleanup) or False
+        self.workspace_setup()
+
+        # Propagate/compute parameters
+        self.apacheds_bin = apacheds_bin or self.find_daemon('wrapper')
+        self.apacheds_conf = apacheds_conf or self.find_configuration()
+        self.stdout_file = os.path.join(self.log_path, 'stdout.log')
+        self.stderr_file = os.path.join(self.log_path, 'stderr.log')
+        self.conf_settings = conf_settings or {}
+        self.extra_options = extra_options or {}
+
+        self.host = host or 'localhost'
+        self.port = port or 10389
+        self.tls  = asbool(tls) or False
+
+        uri_schema = 'ldap'
+        if self.tls: uri_schema = 'ldaps'
+        self.uri = '{schema}://{host}:{port}'.format(schema=uri_schema, **self.__dict__)
+
+        logger.info(u'Initializing server layer "{__name__}" ({__classname__}) ' \
+                    u'on port={port}, workingdir={workingdir}'.format(**self.__dict__))
+
+        self.setup_server()
+
+    def compute_settings(self):
+        """
+        Compute settings for configuration file ``slapd.conf``.
+        Uses some reasonable defaults and merges in obtained
+        settings from ``self.conf_settings``.
+        Outputs its efforts to ``self.settings``.
+        """
+
+        defaults = {
+            'rootdn': 'uid=admin,ou=system',
+            'rootpw': 'secret',
+            }
+        settings = defaults.copy()
+        settings.update(self.conf_settings)
+
+        self.settings = settings
+
+    def setUp(self):
+        """
+        Setup the layer after computing the configuration
+        settings and writing them to an appropriate ``slapd.conf``.
+        """
+        self.compute_settings()
+        #self.write_config()
+        self.start()
+
+    def setup_server(self):
+        """
+        Start the ApacheDS daemon and capture its STDOUT and STDERR channels.
+
+        export INSTANCE_DIRECTORY=`pwd`/instances/default
+        /usr/local/apacheds-2.0.0-M23/bin/wrapper --console /usr/local/apacheds-2.0.0-M23/conf/wrapper.conf wrapper.debug=true
+
+        """
+        ServerLayer.__init__(self, self.__name__, stdout=self.stdout_file, stderr=self.stderr_file)
+
+        # Compute "self.start_cmd"
+        os.environ['INSTANCE_DIRECTORY'] = self.workingdir
+
+        # FIXME: *Optionally* use wrapper.debug=true
+        cmd_arguments_string = u'--console "{configfile}" wrapper.debug=true'.format(configfile=self.apacheds_conf)
+        self.start_cmd = u'{program} {arguments}'.format(program=self.apacheds_bin, arguments=cmd_arguments_string)
+        print >>sys.stderr, 'self.start_cmd:', self.start_cmd
+        logger.debug('start_cmd=%s' % self.start_cmd)
+
+        # compute "self.servers"
+        self.servers = [
+            (self.host, int(self.port)),
+        ]
+
+    def stop(self):
+
+        # Apply special forces
+        self.process.terminate()
+
+        self.process.wait()
+
+        if self.stdout and not self.stdout.closed:
+            self.stdout.close()
+        if self.stderr and not self.stderr.closed:
+            self.stderr.close()
+
+    def tearDown(self):
+        """
+        Tear down the test layer. Remove the working directory.
+        """
+        ServerLayer.tearDown(self)
+        # TODO:
+        # maybe differentiate between cleaning up the working directory
+        # on startup versus cleaning it up on teardown
+        logger.info('Removing workspace directory "%s"' % self.workingdir)
+        self.workspace_cleanup()

--- a/src/lovely/testlayers/apacheds.txt
+++ b/src/lovely/testlayers/apacheds.txt
@@ -1,0 +1,115 @@
+===================
+ApacheDS test layer
+===================
+
+.. note::
+
+    To run this test::
+
+        bin/buildout install apacheds-test
+        bin/test-apacheds --test=apacheds
+
+
+Introduction
+============
+
+| For information about ApacheDS see:
+| https://directory.apache.org/apacheds/
+
+The ``ApacheDSLayer`` starts and stops a single ApacheDS instance.
+
+
+Setup
+=====
+Go to https://directory.apache.org/apacheds/downloads.html
+
+
+Single server
+=============
+
+Warming up
+----------
+We create a new ApacheDS layer::
+
+    >>> from lovely.testlayers import apacheds
+
+    # Initialize layer object
+    >>> server = apacheds.ApacheDSLayer('apacheds', port=10389)
+
+    >>> server.port
+    10389
+
+So let's bootstrap the server::
+
+    >>> server.setUp()
+
+
+Pre flight checks
+-----------------
+Now the OpenLDAP server is up and running. We test this by connecting
+to the storage port via telnet::
+
+    >>> import telnetlib
+    >>> tn = telnetlib.Telnet('localhost', server.port)
+    >>> tn.close()
+
+
+Getting real
+------------
+
+Connect to it using a real OpenLDAP client::
+
+    >>> import ldap
+    >>> client = ldap.initialize('ldap://localhost:10389')
+    >>> client.simple_bind_s('uid=admin,ou=system', 'secret')
+    (97, [], 1, [])
+
+An empty DIT is - empty::
+
+    >>> client.search_s('dc=test,dc=example,dc=com', ldap.SCOPE_SUBTREE, '(cn=Hotzenplotz*)', ['cn','mail'])
+    Traceback (most recent call last):
+    ...
+    NO_SUCH_OBJECT: {'info': "NO_SUCH_OBJECT: failed for MessageType : SEARCH_REQUEST...
+
+Insert some data::
+
+    Create DIT context for suffix
+    >>> record = [('objectclass', ['dcObject', 'organization']), ('o', 'Test Organization'), ('dc', 'test')]
+    >>> client.add_s('dc=test,dc=example,dc=com', record)
+    (105, [])
+
+    Create container for users
+    >>> record = [('objectclass', ['top', 'organizationalUnit']), ('ou', 'users')]
+    >>> client.add_s('ou=users,dc=test,dc=example,dc=com', record)
+    (105, [])
+
+    Create single user
+    >>> record = [
+    ...     ('objectclass', ['top', 'person', 'organizationalPerson', 'inetOrgPerson']),
+    ...     ('cn', 'User 1'), ('sn', 'User 1'), ('uid', 'user1@test.example.com'),
+    ...     ('userPassword', '{SSHA}DnIz/2LWS6okrGYamkg3/R4smMu+h2gM')
+    ... ]
+    >>> client.add_s('cn=User 1,ou=users,dc=test,dc=example,dc=com', record)
+    (105, [])
+
+And query it::
+
+    >>> client.search_s('dc=test,dc=example,dc=com', ldap.SCOPE_SUBTREE, '(uid=user1@test.example.com)', ['cn', 'uid'])
+    [('cn=User 1,ou=users,dc=test,dc=example,dc=com', {'uid': ['user1@test.example.com'], 'cn': ['User 1']})]
+
+
+
+Clean up
+--------
+
+Layers
+______
+
+The connection is refused after teardown::
+
+    >>> server.tearDown()
+
+    >>> telnetlib.Telnet('localhost', server.port)
+    Traceback (most recent call last):
+    ...
+    error:...Connection refused

--- a/src/lovely/testlayers/mongodb_masterslave.txt
+++ b/src/lovely/testlayers/mongodb_masterslave.txt
@@ -3,6 +3,7 @@ MongoDB test layer - master/slave setup
 =======================================
 
 .. note::
+
     To run this test::
 
         bin/buildout install mongodb mongodb-test

--- a/src/lovely/testlayers/mongodb_replicaset.txt
+++ b/src/lovely/testlayers/mongodb_replicaset.txt
@@ -3,6 +3,7 @@ MongoDB test layer - replica set setup
 ======================================
 
 .. note::
+
     To run this test::
 
         bin/buildout install mongodb mongodb-test

--- a/src/lovely/testlayers/mongodb_single.txt
+++ b/src/lovely/testlayers/mongodb_single.txt
@@ -3,6 +3,7 @@ MongoDB test layer - single server setup
 ========================================
 
 .. note::
+
     To run this test::
 
         bin/buildout install mongodb mongodb-test

--- a/src/lovely/testlayers/openldap.py
+++ b/src/lovely/testlayers/openldap.py
@@ -1,0 +1,407 @@
+##############################################################################
+#
+# Copyright 2016 Andreas Motl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
+
+"""
+``lovely.testlayers.openldap``
+
+Test layer for OpenLDAP:
+
+- The ``OpenLDAPLayer`` starts and stops a single OpenLDAP instance.
+"""
+import os
+import sys
+import types
+import shlex
+import logging
+import subprocess
+from copy import deepcopy
+from collections import OrderedDict
+from lovely.testlayers.util import asbool
+from lovely.testlayers.layer import WorkspaceLayer
+from lovely.testlayers.server import ServerLayer
+
+# Setup logging
+console = logging.StreamHandler()
+console.setFormatter(
+    logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s'))
+logger = logging.getLogger(__name__)
+logger.addHandler(console)
+logger.setLevel(logging.INFO)
+
+
+class OpenLDAPConfigurationMixin(object):
+    """
+    Class providing utility functions driving the configuration
+    setting mungling as a mixin for ``OpenLDAPLayer``.
+    """
+
+    # Candidate directories for looking for LDAP schema files
+    schema_dir_candidates = [
+
+        # Debian Linux
+        '/etc/ldap/schema',
+
+        # CentOS Linux
+        '/etc/openldap/schema',
+
+        # Mac OS X, Macports
+        '/opt/local/etc/openldap/schema'
+    ]
+
+    # The settings to be written to ``slapd.conf``, in proper order.
+    setting_keys = [
+        'moduleload',
+        'include',
+        'pidfile',
+        'argsfile',
+        'database',
+        'suffix',
+        'rootdn',
+        'rootpw',
+        'directory',
+        'index',
+    ]
+
+    # -------------------
+    # slapd configuration
+    # -------------------
+
+    def compute_settings(self):
+        """
+        Compute settings for configuration file ``slapd.conf``.
+        Uses some reasonable defaults and merges in obtained
+        settings from ``self.conf_settings``.
+        Outputs its efforts to ``self.settings``.
+        """
+
+        defaults = {
+            'moduleload': 'back_bdb.la',
+            'database': 'bdb',
+            'directory': self.var_path,
+            'pidfile': os.path.join(self.run_path, 'slapd.pid'),
+            'argsfile': os.path.join(self.run_path, 'slapd.args'),
+            'index':  'objectClass eq',
+            'suffix': '"dc=test,dc=example,dc=com"',
+            'rootdn': '"cn=admin,dc=test,dc=example,dc=com"',
+            'rootpw': 'secret',
+            }
+        settings = defaults.copy()
+        settings.update(self.conf_settings)
+
+        self.settings = settings
+
+    def write_config(self):
+        """
+        Write configuration file ``slapd.conf``.
+        Optionally use preseed file from ``self.conf_blueprint``
+        and add more settings from ``self.settings`` computed above.
+        """
+
+        blueprint = ''
+        if self.conf_blueprint and os.path.isfile(self.conf_blueprint):
+            blueprint = file(self.conf_blueprint).read()
+
+        payload = self.make_config()
+
+        # Debugging
+        #print >>sys.stderr, 'payload:\n', payload
+
+        with file(self.slapd_conf, 'w') as f:
+            if blueprint:
+                f.write(blueprint)
+                f.write('\n')
+            f.write(payload)
+
+    def make_config(self):
+        """
+        Serialize ``self.settings`` to appropriate ``slapd.conf`` configuration file.
+        Order matters.
+        """
+        entries = []
+
+        settings = deepcopy(self.settings)
+
+        # Add configuration settings in specific order
+        for key in self.setting_keys:
+            if key in settings:
+                value = settings[key]
+                entries.append(self.serialize_setting(key, value))
+                del settings[key]
+
+        # Add remaining configuration settings at bottom
+        for key, value in settings.iteritems():
+            entries.append(self.serialize_setting(key, value))
+
+        payload = '\n'.join(entries)
+
+        return payload
+
+    def serialize_setting(self, key, value):
+        """
+        Serialize a single configuration setting parameter pair into appropriate format for ``slapd.conf``.
+        """
+        if isinstance(value, types.StringTypes):
+            entry = '{key:<12}{value}'.format(key=key, value=value)
+        elif isinstance(value, types.ListType):
+            lines = []
+            for value in value:
+                line = self.serialize_setting(key, value)
+                lines.append(line)
+            entry = '\n'.join(lines)
+        else:
+            raise TypeError('Unable to serialize setting value of type {type}'.format(type=type(value)))
+        return entry
+
+
+    # --------------
+    # Schema helpers
+    # --------------
+
+    def add_schema(self, schemafile):
+        """
+        Add schemafile as a "include" configuration setting,
+        to ``self.settings`` if not already included.
+        """
+        if not self.schema_included(schemafile):
+            schemapath = self.find_schema(schemafile)
+            if schemapath:
+                self.include_schema(schemapath)
+
+    def include_schema(self, schemapath):
+        """
+        Append full path to schemafile to settings stage data.
+        """
+        self.conf_settings['include'].append(schemapath)
+
+    def schema_included(self, schemafile):
+        """
+        Whether a schemafile is already present in settings stage data.
+        """
+        for include_entry in self.conf_settings['include']:
+            if schemafile in include_entry:
+                return True
+        return False
+
+    def find_schema(self, schemafile):
+        """
+        Find schemafile by searching in listed candidate paths.
+        """
+        for schema_dir in self.schema_dir_candidates:
+            schema_path = os.path.join(schema_dir, schemafile)
+            if os.path.exists(schema_path):
+                return schema_path
+
+
+class OpenLDAPLayerClientMixin(object):
+    """
+    Some methods for convenient access to LDAP client tools.
+    ``ldapadd`` is obligatory for provisioning LDAP servers
+    with a DIT to run software tests against.
+    """
+
+    # ------------
+    # Client tools
+    # ------------
+
+    def ldapadd(self, ldif_file):
+
+        # TODO: Currently, ``ldapadd`` can only be executed if it's on the search $PATH.
+
+        #self.compute_settings()
+
+        command = 'ldapadd -H {uri} -D {rootdn} -w {rootpw} -f {ldif_file} -c'.format(uri=self.uri, ldif_file=ldif_file, **self.settings)
+        cmd = shlex.split(command)
+        subprocess.CalledProcessError.__str__ = lambda self: "Command '%s' returned non-zero exit status %d. Output was:\n%s" % (self.cmd, self.returncode, self.output)
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
+        except subprocess.CalledProcessError as ex:
+            # Ignore "ldap_add: Already exists (68)"
+            if ex.returncode != 68:
+                raise
+
+
+class OpenLDAPLayer(WorkspaceLayer, ServerLayer, OpenLDAPConfigurationMixin, OpenLDAPLayerClientMixin):
+    """
+    Encapsulates controlling a single OpenLDAP instance.
+    """
+
+    __bases__ = ()
+
+    daemon_candidates = [
+
+        # Linux
+        '/usr/sbin/slapd',
+
+        # Mac OS X, Macports
+        '/opt/local/libexec/slapd',
+    ]
+
+    def __init__(self, name, slapd_bin=None,
+                 host=None, port=None, tls=False,
+                 conf_blueprint=None, conf_settings=None,
+                 cleanup=True, extra_options=None):
+        """
+        Settings for ``OpenLDAPLayer``
+
+        :name: (required)
+            The first and only positional argument is the layer name.
+
+        :slapd_bin:
+            The path to ``slapd``, defaults to finding the executable
+            by honoring $PATH and self.daemon_candidates.
+
+        :host:
+            The hostname to be used for computing the LDAP URI, which in turn gets used
+            by ``ldapadd`` for provisioning the OpenLDAP DIT from appropriate LDIF files.
+            Defaults to ``localhost``.
+
+        :port:
+            On which port OpenLDAP should listen, defaults to ``389``.
+
+        :tls:
+            Controls LDAP URI schema: ldap:// vs. ldaps://
+            Defaults to ``False``.
+
+        :conf_blueprint:
+            Path to initial configuration file to use as a preseed for generating
+            the appropriate slapd.conf. Optional.
+
+        :conf_settings:
+            Dictionary containing configuration settings to be propagated into ``slapd.conf``.
+            When empty, reasonable defaults will apply (see ``OpenLDAPConfigurationMixin.compute_settings``)::
+
+                'suffix': '"dc=test,dc=example,dc=org"',
+                'rootdn': '"cn=admin,dc=test,dc=example,dc=org"',
+                'rootpw': 'secret',
+
+        :cleanup:
+            Whether to erase the workspace directory on setup and teardown.
+            Defaults to ``True``.
+
+        :extra_options:
+            Additional command line options to be passed to the daemon executable,
+            defaults to empty dictionary. Currently unused.
+
+            ATTENTION: CURRENTLY NOT WORKING WITH OpenLDAP. There are no extra_options.
+
+        """
+
+        # Essential attributes
+        self.__name__ = name
+        self.__classname__ = self.__class__.__name__
+
+        # Setup workspace
+        self.directories = ('etc', 'log', 'run', 'var')
+        self.cleanup = asbool(cleanup) or False
+        self.workspace_setup()
+
+        # Propagate/compute parameters
+        self.slapd_bin = slapd_bin or self.find_daemon('slapd')
+        self.slapd_conf = os.path.join(self.etc_path, 'slapd.conf')
+        self.stdout_file = os.path.join(self.log_path, 'stdout.log')
+        self.stderr_file = os.path.join(self.log_path, 'stderr.log')
+        self.conf_blueprint = conf_blueprint
+        self.conf_settings = conf_settings or {}
+        self.extra_options = extra_options or {}
+
+        self.conf_settings.setdefault('include', [])
+
+        self.host = host or 'localhost'
+        self.port = port or 389
+        self.tls  = asbool(tls) or False
+
+        uri_schema = 'ldap'
+        if self.tls: uri_schema = 'ldaps'
+        self.uri = '{schema}://{host}:{port}'.format(schema=uri_schema, **self.__dict__)
+
+        logger.info(u'Initializing server layer "{__name__}" ({__classname__}) ' \
+                    u'on port={port}, workingdir={workingdir}'.format(**self.__dict__))
+
+        self.setup_server()
+
+    def setUp(self):
+        """
+        Setup the layer after computing the configuration
+        settings and writing them to an appropriate ``slapd.conf``.
+        """
+        self.compute_settings()
+        self.write_config()
+        self.start()
+
+    def setup_server(self):
+        """
+        Start the ``slapd`` daemon and capture its STDOUT and STDERR channels.
+        """
+        ServerLayer.__init__(self, self.__name__, stdout=self.stdout_file, stderr=self.stderr_file)
+
+        # Compute "self.start_cmd"
+
+        cmd_arguments = OrderedDict()
+        cmd_arguments['f'] = self.slapd_conf
+        cmd_arguments['h'] = self.uri
+        # FIXME: Use debug log level from yet another parameter
+        cmd_arguments['d'] = 255
+        cmd_arguments_string = self.serialize_arguments(cmd_arguments)
+
+        self.start_cmd = u'{program} {arguments}'.format(program=self.slapd_bin, arguments=cmd_arguments_string)
+        print >>sys.stderr, 'self.start_cmd:', self.start_cmd
+        logger.debug('start_cmd=%s' % self.start_cmd)
+
+        # compute "self.servers"
+        self.servers = [
+            (self.host, int(self.port)),
+        ]
+
+    def start(self):
+        """
+        Propagates start operation to ``ServerLayer``.
+        Beforehand, brutally removes pid- and lock-files
+        to be graceful if the last shutdown went wrong.
+        """
+        #print >>sys.stderr, 'self.settings:', self.settings
+        os.path.exists(self.settings['pidfile']) and os.unlink(self.settings['pidfile'])
+        os.path.exists(self.settings['argsfile']) and os.unlink(self.settings['argsfile'])
+        ServerLayer.start(self)
+
+    def serialize_arguments(self, arguments):
+        """
+        Helper function to serialize a dictionary of
+        commandline arguments into a string.
+        """
+        argument_list = []
+        for key, value in arguments.iteritems():
+            if not value:
+                continue
+            elif value is True:
+                argument_item = '-%s' % key
+            else:
+                argument_item = "-%s '%s'" % (key, value)
+            argument_list.append(argument_item)
+        return ' '.join(argument_list)
+
+    def tearDown(self):
+        """
+        Tear down the test layer. Remove the working directory.
+        """
+        ServerLayer.tearDown(self)
+        # TODO:
+        # maybe differentiate between cleaning up the working directory
+        # on startup versus cleaning it up on teardown
+        logger.info('Removing workspace directory "%s"' % self.workingdir)
+        self.workspace_cleanup()

--- a/src/lovely/testlayers/openldap.txt
+++ b/src/lovely/testlayers/openldap.txt
@@ -1,0 +1,131 @@
+===================
+OpenLDAP test layer
+===================
+
+.. note::
+
+    To run this test::
+
+        bin/buildout install openldap-test
+        bin/test-openldap --test=openldap
+
+
+Introduction
+============
+
+| For information about OpenLDAP see:
+| http://www.openldap.org/
+
+The ``OpenLDAPLayer`` starts and stops a single OpenLDAP instance.
+
+
+Setup
+=====
+Debian Linux::
+
+    aptitude install slapd
+
+CentOS Linux::
+
+    yum install openldap-servers
+
+Mac OS X, Macports::
+
+    sudo port install openldap
+
+
+
+Single server
+=============
+
+Warming up
+----------
+We create a new OpenLDAP layer::
+
+    >>> from lovely.testlayers import openldap
+
+    # Initialize layer object
+    >>> server = openldap.OpenLDAPLayer('openldap', port=3389)
+
+    # Add essential schemas
+    >>> server.add_schema('core.schema')
+    >>> server.add_schema('cosine.schema')
+    >>> server.add_schema('inetorgperson.schema')
+
+    >>> server.port
+    3389
+
+So let's bootstrap the server::
+
+    >>> server.setUp()
+
+
+Pre flight checks
+-----------------
+Now the OpenLDAP server is up and running. We test this by connecting
+to the storage port via telnet::
+
+    >>> import telnetlib
+    >>> tn = telnetlib.Telnet('localhost', server.port)
+    >>> tn.close()
+
+
+Getting real
+------------
+
+Connect to it using a real OpenLDAP client::
+
+    >>> import ldap
+    >>> client = ldap.initialize('ldap://localhost:3389')
+    >>> client.simple_bind_s('cn=admin,dc=test,dc=example,dc=com', 'secret')
+    (97, [], 1, [])
+
+An empty DIT is - empty::
+
+    >>> client.search_s('dc=test,dc=example,dc=com', ldap.SCOPE_SUBTREE, '(cn=Hotzenplotz*)', ['cn','mail'])
+    Traceback (most recent call last):
+    ...
+    NO_SUCH_OBJECT: {'desc': 'No such object'}
+
+Insert some data::
+
+    Create DIT context for suffix
+    >>> record = [('objectclass', ['dcObject', 'organization']), ('o', 'Test Organization'), ('dc', 'test')]
+    >>> client.add_s('dc=test,dc=example,dc=com', record)
+    (105, [])
+
+    Create container for users
+    >>> record = [('objectclass', ['top', 'organizationalUnit']), ('ou', 'users')]
+    >>> client.add_s('ou=users,dc=test,dc=example,dc=com', record)
+    (105, [])
+
+    Create single user
+    >>> record = [
+    ...     ('objectclass', ['top', 'person', 'organizationalPerson', 'inetOrgPerson']),
+    ...     ('cn', 'User 1'), ('sn', 'User 1'), ('uid', 'user1@test.example.com'),
+    ...     ('userPassword', '{SSHA}DnIz/2LWS6okrGYamkg3/R4smMu+h2gM')
+    ... ]
+    >>> client.add_s('cn=User 1,ou=users,dc=test,dc=example,dc=com', record)
+    (105, [])
+
+And query it::
+
+    >>> client.search_s('dc=test,dc=example,dc=com', ldap.SCOPE_SUBTREE, '(uid=user1@test.example.com)', ['cn', 'uid'])
+    [('cn=User 1,ou=users,dc=test,dc=example,dc=com', {'cn': ['User 1'], 'uid': ['user1@test.example.com']})]
+
+
+
+Clean up
+--------
+
+Layers
+______
+
+The connection is refused after teardown::
+
+    >>> server.tearDown()
+
+    >>> telnetlib.Telnet('localhost', server.port)
+    Traceback (most recent call last):
+    ...
+    error:...Connection refused

--- a/src/lovely/testlayers/tests.py
+++ b/src/lovely/testlayers/tests.py
@@ -98,5 +98,32 @@ def mongodb_suite():
     )
     return unittest.TestSuite(suites)
 
+
+def openldap_suite():
+    """
+    A test suite for running OpenLDAP tests, boot it by issuing::
+
+        bin/buildout install openldap-test
+        bin/test-openldap --suite-name=openldap_suite
+    """
+    suites = (
+        create_suite('openldap.txt'),
+        )
+    return unittest.TestSuite(suites)
+
+
+def apacheds_suite():
+    """
+    A test suite for running ApacheDS tests, boot it by issuing::
+
+        bin/buildout install apacheds-test
+        bin/test-apacheds --suite-name=apacheds_suite
+    """
+    suites = (
+        create_suite('apacheds.txt'),
+        )
+    return unittest.TestSuite(suites)
+
+
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')

--- a/src/lovely/testlayers/util.py
+++ b/src/lovely/testlayers/util.py
@@ -1,5 +1,7 @@
 import os
+import types
 import socket
+import logging
 
 def isUp(host, port):
     """test if a host is up"""
@@ -29,3 +31,34 @@ def system(c):
 
     if os.system(c):
         raise SystemError("Failed", c)
+
+
+class DuplicateSuppressingLogFilter(logging.Filter):
+    """
+    Suppress duplicate log messages.
+    """
+
+    def __init__(self):
+        self.last_message = None
+
+    def filter(self, record):
+        outcome = self.last_message != record.msg
+        self.last_message = record.msg
+        return outcome
+
+
+# (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
+# Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
+# From beaker.converters.asbool
+def asbool(obj):
+    if isinstance(obj, types.StringTypes):
+        obj = obj.strip().lower()
+        if obj in ['true', 'yes', 'on', 'y', 't', '1']:
+            return True
+        elif obj in ['false', 'no', 'off', 'n', 'f', '0']:
+            return False
+        else:
+            raise ValueError(
+                "String is not true/false: %r" % obj)
+    return bool(obj)
+


### PR DESCRIPTION
Dear Lovely Systems,

we added two convenient server layers for OpenLDAP and ApacheDS.

To install and run their test suites:

    bin/buildout install openldap-test apacheds-test
    bin/test-openldap
    bin/test-apacheds

Cheers,
Andreas.

----

P.S.: The relevant system packages have to be installed separately.

- OpenLDAP:

    Debian Linux:

        aptitude install slapd openldap-utils libldap2-dev libsasl2-dev

    CentOS Linux:

         yum install openldap-servers openldap-clients

    Mac OS X, Macports:

        sudo port install openldap

- ApacheDS
  - https://directory.apache.org/apacheds/downloads.html
  - Also, a Java runtime is required:

          aptitude install default-jre-headless
